### PR TITLE
Migrate setup.py to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,42 @@
+[metadata]
+name = LpCli
+version = 0.1
+description = A Command Line helper to get data out of LaunchPad.
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/mclemenceau/lp-cli
+project_urls =
+    Bug Reports = https://github.com/mclemenceau/lp-cli/issues
+    Source Code = https://github.com/mclemenceau/lp-cli
+classifiers =
+    Development Status :: 3 - Alpha
+    License :: OSI Approved :: GNU General Public License v2 (GPLv2)
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+
+[options]
+install_requires =
+    launchpadlib
+
+[options.extras_require]
+test =
+    pytest
+    pytest-cov
+
+[options.entry_points]
+console_scripts =
+    lp-cli = LpCli.lp_cli:main
+
+[tool:pytest]
+addopts = --cov
+testpaths = tests
+
+[coverage:run]
+source = LpCli
+branch = true
+
+[coverage:report]
+show_missing = true
+exclude_lines =
+    raise NotImplementedError
+    assert False

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,3 @@
-import setuptools
-
 from setuptools import setup
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-setup(
-    name="LpCli",
-    version="0.1",
-    author="Matthieu Clemenceau",
-    author_email="matthieu.clemenceau@canonical.com",
-    description=("A Command Line helper to get data out of LaunchPad."),
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/mclemenceau/lp-cli",
-    project_urls={
-        'Bug Reports': 'https://github.com/mclemenceau/lp-cli/issues',
-        'Source': 'https://github.com/mclemenceau/lp-cli',
-    },
-    packages=setuptools.find_packages(),
-    entry_points={
-        'console_scripts': [
-            'lp-cli=LpCli.lp_cli:main'
-        ],
-    },
-    install_requires=['launchpadlib'],
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-        "Operating System :: OS Independent",
-    ],
-)
+setup()


### PR DESCRIPTION
The Python community is generally trying to move away from setup.py as having an arbitrary script for package installation isn't ideal, and a nice declarative format (like setup.cfg or pyproject.toml) is generally preferable.

Personally I like setup.cfg (as it uses a format parseable entirely by the stdlib); however, a sizeable portion of the community seems to prefer pyproject.toml. The vestigial setup.py may seem pointless but is still required in certain scenarios (I forget what off the top of my head; only that they exist :)

This branch simply migrates the existing setup.py to setup.cfg and adds some relevant sections to store pytest and coverage settings. That in turn means you can just run "pytest" and get a full coverage report thrown in.